### PR TITLE
Refactor G-code, use G0 for non-extruding linear moves

### DIFF
--- a/src/WiperTool/lib/gcode.ts
+++ b/src/WiperTool/lib/gcode.ts
@@ -159,7 +159,7 @@ function generateWipingSequenceGCodeCommands({
 
   points.forEach((pt) => {
     const coords = relativeToAbsolute(pt, padTopRight);
-    gCode.push(gCodeCommands.linearMove(coords, feedRate));
+    gCode.push(gCodeCommands.linearMove({ ...coords, z: zHeight }, feedRate));
   });
 
   const zLiftHeight = padTopRight.z - plungeDepth + zLift;


### PR DESCRIPTION
Refactor the G-code generation and provide a `gCodeCommands` library with all the commands to avoid command duplication.

Non-extruding moves now use `G0` instead of `G1`, fixes #7.